### PR TITLE
Add endpoint for single event

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ flask = "*"
 campuspulse-event-ingest-schema = "*"
 flask-cors = "*"
 icalendar = "*"
+ics = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ flask = "*"
 campuspulse-event-ingest-schema = "*"
 flask-cors = "*"
 icalendar = "*"
-ics = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,305 +1,263 @@
 {
-    "_meta": {
-        "hash": {
-            "sha256": "15735d850f4d2a3051311c0918e1877013e1e278a5469fb37e7dfa539fa83f87"
-        },
-        "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.10"
-        },
-        "sources": [
-            {
-                "name": "pypi",
-                "url": "https://pypi.org/simple",
-                "verify_ssl": true
-            }
-        ]
+  "_meta": {
+    "hash": {
+      "sha256": "48868ea679f12152625268a20a367f4e297b81bc25c751bcd6a5843cfb4e0bed"
     },
-    "default": {
-        "arrow": {
-            "hashes": [
-                "sha256:c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80",
-                "sha256:d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.3.0"
-        },
-        "attrs": {
-            "hashes": [
-                "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e",
-                "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==25.1.0"
-        },
-        "blinker": {
-            "hashes": [
-                "sha256:1779309f71bf239144b9399d06ae925637cf6634cf6bd131104184531bf67c01",
-                "sha256:8f77b09d3bf7c795e969e9486f39c2c5e9c39d4ee07424be2bc594ece9642d83"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.8.2"
-        },
-        "campuspulse-event-ingest-schema": {
-            "hashes": [
-                "sha256:848d7b7e9cf472d087a7df1524ee718b6ee5adf76e798eeebec0edb4f2f8237e",
-                "sha256:bac265abe1db151b5770d4f43697b87aed682f9305d6062e4a73af07b5438c9f"
-            ],
-            "index": "pypi",
-            "version": "==0.1.0"
-        },
-        "click": {
-            "hashes": [
-                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
-                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==8.1.7"
-        },
-        "dnspython": {
-            "hashes": [
-                "sha256:5ef3b9680161f6fa89daf8ad451b5f1a33b18ae8a1c6778cdf4b43f08c0a6e50",
-                "sha256:e8f0f9c23a7b7cb99ded64e6c3a6f3e701d78f50c55e002b839dea7225cff7cc"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.6.1"
-        },
-        "email-validator": {
-            "hashes": [
-                "sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631",
-                "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7"
-            ],
-            "version": "==2.2.0"
-        },
-        "flask": {
-            "hashes": [
-                "sha256:34e815dfaa43340d1d15a5c3a02b8476004037eb4840b34910c6e21679d288f3",
-                "sha256:ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842"
-            ],
-            "index": "pypi",
-            "version": "==3.0.3"
-        },
-        "flask-cors": {
-            "hashes": [
-                "sha256:eeb69b342142fdbf4766ad99357a7f3876a2ceb77689dc10ff912aac06c389e4",
-                "sha256:f2a704e4458665580c074b714c4627dd5a306b333deb9074d0b1794dfa2fb677"
-            ],
-            "index": "pypi",
-            "version": "==4.0.1"
-        },
-        "icalendar": {
-            "hashes": [
-                "sha256:5ded5415e2e1edef5ab230024a75878a7a81d518a3b1ae4f34bf20b173c84dc2",
-                "sha256:92799fde8cce0b61daa8383593836d1e19136e504fa1671f471f98be9b029706"
-            ],
-            "index": "pypi",
-            "version": "==5.0.13"
-        },
-        "ics": {
-            "hashes": [
-                "sha256:5fcf4d29ec6e7dfcb84120abd617bbba632eb77b097722b7df70e48dbcf26103",
-                "sha256:6743539bca10391635249b87d74fcd1094af20b82098bebf7c7521df91209f05"
-            ],
-            "index": "pypi",
-            "version": "==0.7.2"
-        },
-        "idna": {
-            "hashes": [
-                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
-                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.7"
-        },
-        "itsdangerous": {
-            "hashes": [
-                "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef",
-                "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.2.0"
-        },
-        "jinja2": {
-            "hashes": [
-                "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
-                "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.1.4"
-        },
-        "markupsafe": {
-            "hashes": [
-                "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf",
-                "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff",
-                "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f",
-                "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3",
-                "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532",
-                "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f",
-                "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617",
-                "sha256:2d2d793e36e230fd32babe143b04cec8a8b3eb8a3122d2aceb4a371e6b09b8df",
-                "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4",
-                "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906",
-                "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f",
-                "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4",
-                "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8",
-                "sha256:4096e9de5c6fdf43fb4f04c26fb114f61ef0bf2e5604b6ee3019d51b69e8c371",
-                "sha256:4275d846e41ecefa46e2015117a9f491e57a71ddd59bbead77e904dc02b1bed2",
-                "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465",
-                "sha256:4f11aa001c540f62c6166c7726f71f7573b52c68c31f014c25cc7901deea0b52",
-                "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6",
-                "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169",
-                "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad",
-                "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2",
-                "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0",
-                "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029",
-                "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f",
-                "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a",
-                "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced",
-                "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5",
-                "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c",
-                "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf",
-                "sha256:7b2e5a267c855eea6b4283940daa6e88a285f5f2a67f2220203786dfa59b37e9",
-                "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb",
-                "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad",
-                "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3",
-                "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1",
-                "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46",
-                "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc",
-                "sha256:a549b9c31bec33820e885335b451286e2969a2d9e24879f83fe904a5ce59d70a",
-                "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee",
-                "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900",
-                "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5",
-                "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea",
-                "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f",
-                "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5",
-                "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e",
-                "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a",
-                "sha256:c8b29db45f8fe46ad280a7294f5c3ec36dbac9491f2d1c17345be8e69cc5928f",
-                "sha256:ce409136744f6521e39fd8e2a24c53fa18ad67aa5bc7c2cf83645cce5b5c4e50",
-                "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a",
-                "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
-                "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4",
-                "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff",
-                "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2",
-                "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46",
-                "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b",
-                "sha256:ec6a563cff360b50eed26f13adc43e61bc0c04d94b8be985e6fb24b81f6dcfdf",
-                "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5",
-                "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5",
-                "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab",
-                "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd",
-                "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.1.5"
-        },
-        "pydantic": {
-            "extras": [
-                "email"
-            ],
-            "hashes": [
-                "sha256:098ad8de840c92ea586bf8efd9e2e90c6339d33ab5c1cfbb85be66e4ecf8213f",
-                "sha256:0e2495309b1266e81d259a570dd199916ff34f7f51f1b549a0d37a6d9b17b4dc",
-                "sha256:0fa51175313cc30097660b10eec8ca55ed08bfa07acbfe02f7a42f6c242e9a4b",
-                "sha256:11289fa895bcbc8f18704efa1d8020bb9a86314da435348f59745473eb042e6b",
-                "sha256:2a72d2a5ff86a3075ed81ca031eac86923d44bc5d42e719d585a8eb547bf0c9b",
-                "sha256:371dcf1831f87c9e217e2b6a0c66842879a14873114ebb9d0861ab22e3b5bb1e",
-                "sha256:409b2b36d7d7d19cd8310b97a4ce6b1755ef8bd45b9a2ec5ec2b124db0a0d8f3",
-                "sha256:4866a1579c0c3ca2c40575398a24d805d4db6cb353ee74df75ddeee3c657f9a7",
-                "sha256:48db882e48575ce4b39659558b2f9f37c25b8d348e37a2b4e32971dd5a7d6227",
-                "sha256:525bbef620dac93c430d5d6bdbc91bdb5521698d434adf4434a7ef6ffd5c4b7f",
-                "sha256:543da3c6914795b37785703ffc74ba4d660418620cc273490d42c53949eeeca6",
-                "sha256:62d96b8799ae3d782df7ec9615cb59fc32c32e1ed6afa1b231b0595f6516e8ab",
-                "sha256:6654028d1144df451e1da69a670083c27117d493f16cf83da81e1e50edce72ad",
-                "sha256:7017971ffa7fd7808146880aa41b266e06c1e6e12261768a28b8b41ba55c8076",
-                "sha256:7623b59876f49e61c2e283551cc3647616d2fbdc0b4d36d3d638aae8547ea681",
-                "sha256:7e17c0ee7192e54a10943f245dc79e36d9fe282418ea05b886e1c666063a7b54",
-                "sha256:820ae12a390c9cbb26bb44913c87fa2ff431a029a785642c1ff11fed0a095fcb",
-                "sha256:94833612d6fd18b57c359a127cbfd932d9150c1b72fea7c86ab58c2a77edd7c7",
-                "sha256:95ef534e3c22e5abbdbdd6f66b6ea9dac3ca3e34c5c632894f8625d13d084cbe",
-                "sha256:9c803a5113cfab7bbb912f75faa4fc1e4acff43e452c82560349fff64f852e1b",
-                "sha256:9e53fb834aae96e7b0dadd6e92c66e7dd9cdf08965340ed04c16813102a47fab",
-                "sha256:ab2f976336808fd5d539fdc26eb51f9aafc1f4b638e212ef6b6f05e753c8011d",
-                "sha256:ad1e33dc6b9787a6f0f3fd132859aa75626528b49cc1f9e429cdacb2608ad5f0",
-                "sha256:ae5184e99a060a5c80010a2d53c99aee76a3b0ad683d493e5f0620b5d86eeb75",
-                "sha256:aeb4e741782e236ee7dc1fb11ad94dc56aabaf02d21df0e79e0c21fe07c95741",
-                "sha256:b4ad32aed3bf5eea5ca5decc3d1bbc3d0ec5d4fbcd72a03cdad849458decbc63",
-                "sha256:b8ad363330557beac73159acfbeed220d5f1bfcd6b930302a987a375e02f74fd",
-                "sha256:bfbb18b616abc4df70591b8c1ff1b3eabd234ddcddb86b7cac82657ab9017e33",
-                "sha256:c1e51d1af306641b7d1574d6d3307eaa10a4991542ca324f0feb134fee259815",
-                "sha256:c31d281c7485223caf6474fc2b7cf21456289dbaa31401844069b77160cab9c7",
-                "sha256:c7e8988bb16988890c985bd2093df9dd731bfb9d5e0860db054c23034fab8f7a",
-                "sha256:c87cedb4680d1614f1d59d13fea353faf3afd41ba5c906a266f3f2e8c245d655",
-                "sha256:cafb9c938f61d1b182dfc7d44a7021326547b7b9cf695db5b68ec7b590214773",
-                "sha256:d2f89a719411cb234105735a520b7c077158a81e0fe1cb05a79c01fc5eb59d3c",
-                "sha256:d4b40c9e13a0b61583e5599e7950490c700297b4a375b55b2b592774332798b7",
-                "sha256:d4ecb515fa7cb0e46e163ecd9d52f9147ba57bc3633dca0e586cdb7a232db9e3",
-                "sha256:d8c209af63ccd7b22fba94b9024e8b7fd07feffee0001efae50dd99316b27768",
-                "sha256:db3b48d9283d80a314f7a682f7acae8422386de659fffaba454b77a083c3937d",
-                "sha256:e41b5b973e5c64f674b3b4720286ded184dcc26a691dd55f34391c62c6934688",
-                "sha256:e840e6b2026920fc3f250ea8ebfdedf6ea7a25b77bf04c6576178e681942ae0f",
-                "sha256:ebb249096d873593e014535ab07145498957091aa6ae92759a32d40cb9998e2e",
-                "sha256:f434160fb14b353caf634149baaf847206406471ba70e64657c1e8330277a991",
-                "sha256:fa43f362b46741df8f201bf3e7dff3569fa92069bcc7b4a740dea3602e27ab7a"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.10.17"
-        },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
-                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==2.9.0.post0"
-        },
-        "pytz": {
-            "hashes": [
-                "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812",
-                "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"
-            ],
-            "version": "==2024.1"
-        },
-        "six": {
-            "hashes": [
-                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
-                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==1.17.0"
-        },
-        "tatsu": {
-            "hashes": [
-                "sha256:941e12df8798f444957600346c52a5ff3455f485de5b4570a3a71a00ed896a14",
-                "sha256:df8c216eecd09af9b5b308624f1bfda1e4b5af3d3df1bdc4f331a1e8ea6bc012"
-            ],
-            "markers": "python_version >= '3.10'",
-            "version": "==5.13.1"
-        },
-        "types-python-dateutil": {
-            "hashes": [
-                "sha256:18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb",
-                "sha256:e248a4bc70a486d3e3ec84d0dc30eec3a5f979d6e7ee4123ae043eedbb987f53"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.9.0.20241206"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
-        },
-        "werkzeug": {
-            "hashes": [
-                "sha256:097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18",
-                "sha256:fc9645dc43e03e4d630d23143a04a7f947a9a3b5727cd535fdfe155a17cc48c8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.0.3"
-        }
+    "pipfile-spec": 6,
+    "requires": {
+      "python_version": "3.10"
     },
-    "develop": {}
+    "sources": [
+      {
+        "name": "pypi",
+        "url": "https://pypi.org/simple",
+        "verify_ssl": true
+      }
+    ]
+  },
+  "default": {
+    "blinker": {
+      "hashes": [
+        "sha256:1779309f71bf239144b9399d06ae925637cf6634cf6bd131104184531bf67c01",
+        "sha256:8f77b09d3bf7c795e969e9486f39c2c5e9c39d4ee07424be2bc594ece9642d83"
+      ],
+      "markers": "python_version >= '3.8'",
+      "version": "==1.8.2"
+    },
+    "campuspulse-event-ingest-schema": {
+      "hashes": [
+        "sha256:848d7b7e9cf472d087a7df1524ee718b6ee5adf76e798eeebec0edb4f2f8237e",
+        "sha256:bac265abe1db151b5770d4f43697b87aed682f9305d6062e4a73af07b5438c9f"
+      ],
+      "index": "pypi",
+      "version": "==0.1.0"
+    },
+    "click": {
+      "hashes": [
+        "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+        "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+      ],
+      "markers": "python_version >= '3.7'",
+      "version": "==8.1.7"
+    },
+    "dnspython": {
+      "hashes": [
+        "sha256:5ef3b9680161f6fa89daf8ad451b5f1a33b18ae8a1c6778cdf4b43f08c0a6e50",
+        "sha256:e8f0f9c23a7b7cb99ded64e6c3a6f3e701d78f50c55e002b839dea7225cff7cc"
+      ],
+      "markers": "python_version >= '3.8'",
+      "version": "==2.6.1"
+    },
+    "email-validator": {
+      "hashes": [
+        "sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631",
+        "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7"
+      ],
+      "version": "==2.2.0"
+    },
+    "flask": {
+      "hashes": [
+        "sha256:34e815dfaa43340d1d15a5c3a02b8476004037eb4840b34910c6e21679d288f3",
+        "sha256:ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842"
+      ],
+      "index": "pypi",
+      "version": "==3.0.3"
+    },
+    "flask-cors": {
+      "hashes": [
+        "sha256:eeb69b342142fdbf4766ad99357a7f3876a2ceb77689dc10ff912aac06c389e4",
+        "sha256:f2a704e4458665580c074b714c4627dd5a306b333deb9074d0b1794dfa2fb677"
+      ],
+      "index": "pypi",
+      "version": "==4.0.1"
+    },
+    "icalendar": {
+      "hashes": [
+        "sha256:5ded5415e2e1edef5ab230024a75878a7a81d518a3b1ae4f34bf20b173c84dc2",
+        "sha256:92799fde8cce0b61daa8383593836d1e19136e504fa1671f471f98be9b029706"
+      ],
+      "index": "pypi",
+      "version": "==5.0.13"
+    },
+    "idna": {
+      "hashes": [
+        "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
+        "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
+      ],
+      "markers": "python_version >= '3.5'",
+      "version": "==3.7"
+    },
+    "itsdangerous": {
+      "hashes": [
+        "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef",
+        "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"
+      ],
+      "markers": "python_version >= '3.8'",
+      "version": "==2.2.0"
+    },
+    "jinja2": {
+      "hashes": [
+        "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
+        "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
+      ],
+      "markers": "python_version >= '3.7'",
+      "version": "==3.1.4"
+    },
+    "markupsafe": {
+      "hashes": [
+        "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf",
+        "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff",
+        "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f",
+        "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3",
+        "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532",
+        "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f",
+        "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617",
+        "sha256:2d2d793e36e230fd32babe143b04cec8a8b3eb8a3122d2aceb4a371e6b09b8df",
+        "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4",
+        "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906",
+        "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f",
+        "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4",
+        "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8",
+        "sha256:4096e9de5c6fdf43fb4f04c26fb114f61ef0bf2e5604b6ee3019d51b69e8c371",
+        "sha256:4275d846e41ecefa46e2015117a9f491e57a71ddd59bbead77e904dc02b1bed2",
+        "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465",
+        "sha256:4f11aa001c540f62c6166c7726f71f7573b52c68c31f014c25cc7901deea0b52",
+        "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6",
+        "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169",
+        "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad",
+        "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2",
+        "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0",
+        "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029",
+        "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f",
+        "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a",
+        "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced",
+        "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5",
+        "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c",
+        "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf",
+        "sha256:7b2e5a267c855eea6b4283940daa6e88a285f5f2a67f2220203786dfa59b37e9",
+        "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb",
+        "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad",
+        "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3",
+        "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1",
+        "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46",
+        "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc",
+        "sha256:a549b9c31bec33820e885335b451286e2969a2d9e24879f83fe904a5ce59d70a",
+        "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee",
+        "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900",
+        "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5",
+        "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea",
+        "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f",
+        "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5",
+        "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e",
+        "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a",
+        "sha256:c8b29db45f8fe46ad280a7294f5c3ec36dbac9491f2d1c17345be8e69cc5928f",
+        "sha256:ce409136744f6521e39fd8e2a24c53fa18ad67aa5bc7c2cf83645cce5b5c4e50",
+        "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a",
+        "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
+        "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4",
+        "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff",
+        "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2",
+        "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46",
+        "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b",
+        "sha256:ec6a563cff360b50eed26f13adc43e61bc0c04d94b8be985e6fb24b81f6dcfdf",
+        "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5",
+        "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5",
+        "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab",
+        "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd",
+        "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"
+      ],
+      "markers": "python_version >= '3.7'",
+      "version": "==2.1.5"
+    },
+    "pydantic": {
+      "extras": ["email"],
+      "hashes": [
+        "sha256:098ad8de840c92ea586bf8efd9e2e90c6339d33ab5c1cfbb85be66e4ecf8213f",
+        "sha256:0e2495309b1266e81d259a570dd199916ff34f7f51f1b549a0d37a6d9b17b4dc",
+        "sha256:0fa51175313cc30097660b10eec8ca55ed08bfa07acbfe02f7a42f6c242e9a4b",
+        "sha256:11289fa895bcbc8f18704efa1d8020bb9a86314da435348f59745473eb042e6b",
+        "sha256:2a72d2a5ff86a3075ed81ca031eac86923d44bc5d42e719d585a8eb547bf0c9b",
+        "sha256:371dcf1831f87c9e217e2b6a0c66842879a14873114ebb9d0861ab22e3b5bb1e",
+        "sha256:409b2b36d7d7d19cd8310b97a4ce6b1755ef8bd45b9a2ec5ec2b124db0a0d8f3",
+        "sha256:4866a1579c0c3ca2c40575398a24d805d4db6cb353ee74df75ddeee3c657f9a7",
+        "sha256:48db882e48575ce4b39659558b2f9f37c25b8d348e37a2b4e32971dd5a7d6227",
+        "sha256:525bbef620dac93c430d5d6bdbc91bdb5521698d434adf4434a7ef6ffd5c4b7f",
+        "sha256:543da3c6914795b37785703ffc74ba4d660418620cc273490d42c53949eeeca6",
+        "sha256:62d96b8799ae3d782df7ec9615cb59fc32c32e1ed6afa1b231b0595f6516e8ab",
+        "sha256:6654028d1144df451e1da69a670083c27117d493f16cf83da81e1e50edce72ad",
+        "sha256:7017971ffa7fd7808146880aa41b266e06c1e6e12261768a28b8b41ba55c8076",
+        "sha256:7623b59876f49e61c2e283551cc3647616d2fbdc0b4d36d3d638aae8547ea681",
+        "sha256:7e17c0ee7192e54a10943f245dc79e36d9fe282418ea05b886e1c666063a7b54",
+        "sha256:820ae12a390c9cbb26bb44913c87fa2ff431a029a785642c1ff11fed0a095fcb",
+        "sha256:94833612d6fd18b57c359a127cbfd932d9150c1b72fea7c86ab58c2a77edd7c7",
+        "sha256:95ef534e3c22e5abbdbdd6f66b6ea9dac3ca3e34c5c632894f8625d13d084cbe",
+        "sha256:9c803a5113cfab7bbb912f75faa4fc1e4acff43e452c82560349fff64f852e1b",
+        "sha256:9e53fb834aae96e7b0dadd6e92c66e7dd9cdf08965340ed04c16813102a47fab",
+        "sha256:ab2f976336808fd5d539fdc26eb51f9aafc1f4b638e212ef6b6f05e753c8011d",
+        "sha256:ad1e33dc6b9787a6f0f3fd132859aa75626528b49cc1f9e429cdacb2608ad5f0",
+        "sha256:ae5184e99a060a5c80010a2d53c99aee76a3b0ad683d493e5f0620b5d86eeb75",
+        "sha256:aeb4e741782e236ee7dc1fb11ad94dc56aabaf02d21df0e79e0c21fe07c95741",
+        "sha256:b4ad32aed3bf5eea5ca5decc3d1bbc3d0ec5d4fbcd72a03cdad849458decbc63",
+        "sha256:b8ad363330557beac73159acfbeed220d5f1bfcd6b930302a987a375e02f74fd",
+        "sha256:bfbb18b616abc4df70591b8c1ff1b3eabd234ddcddb86b7cac82657ab9017e33",
+        "sha256:c1e51d1af306641b7d1574d6d3307eaa10a4991542ca324f0feb134fee259815",
+        "sha256:c31d281c7485223caf6474fc2b7cf21456289dbaa31401844069b77160cab9c7",
+        "sha256:c7e8988bb16988890c985bd2093df9dd731bfb9d5e0860db054c23034fab8f7a",
+        "sha256:c87cedb4680d1614f1d59d13fea353faf3afd41ba5c906a266f3f2e8c245d655",
+        "sha256:cafb9c938f61d1b182dfc7d44a7021326547b7b9cf695db5b68ec7b590214773",
+        "sha256:d2f89a719411cb234105735a520b7c077158a81e0fe1cb05a79c01fc5eb59d3c",
+        "sha256:d4b40c9e13a0b61583e5599e7950490c700297b4a375b55b2b592774332798b7",
+        "sha256:d4ecb515fa7cb0e46e163ecd9d52f9147ba57bc3633dca0e586cdb7a232db9e3",
+        "sha256:d8c209af63ccd7b22fba94b9024e8b7fd07feffee0001efae50dd99316b27768",
+        "sha256:db3b48d9283d80a314f7a682f7acae8422386de659fffaba454b77a083c3937d",
+        "sha256:e41b5b973e5c64f674b3b4720286ded184dcc26a691dd55f34391c62c6934688",
+        "sha256:e840e6b2026920fc3f250ea8ebfdedf6ea7a25b77bf04c6576178e681942ae0f",
+        "sha256:ebb249096d873593e014535ab07145498957091aa6ae92759a32d40cb9998e2e",
+        "sha256:f434160fb14b353caf634149baaf847206406471ba70e64657c1e8330277a991",
+        "sha256:fa43f362b46741df8f201bf3e7dff3569fa92069bcc7b4a740dea3602e27ab7a"
+      ],
+      "markers": "python_version >= '3.7'",
+      "version": "==1.10.17"
+    },
+    "python-dateutil": {
+      "hashes": [
+        "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+        "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+      ],
+      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+      "version": "==2.9.0.post0"
+    },
+    "pytz": {
+      "hashes": [
+        "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812",
+        "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"
+      ],
+      "version": "==2024.1"
+    },
+    "six": {
+      "hashes": [
+        "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+        "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+      ],
+      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+      "version": "==1.16.0"
+    },
+    "typing-extensions": {
+      "hashes": [
+        "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+        "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+      ],
+      "markers": "python_version >= '3.8'",
+      "version": "==4.12.2"
+    },
+    "werkzeug": {
+      "hashes": [
+        "sha256:097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18",
+        "sha256:fc9645dc43e03e4d630d23143a04a7f947a9a3b5727cd535fdfe155a17cc48c8"
+      ],
+      "markers": "python_version >= '3.8'",
+      "version": "==3.0.3"
+    }
+  },
+  "develop": {}
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "48868ea679f12152625268a20a367f4e297b81bc25c751bcd6a5843cfb4e0bed"
+            "sha256": "15735d850f4d2a3051311c0918e1877013e1e278a5469fb37e7dfa539fa83f87"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,22 @@
         ]
     },
     "default": {
+        "arrow": {
+            "hashes": [
+                "sha256:c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80",
+                "sha256:d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e",
+                "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==25.1.0"
+        },
         "blinker": {
             "hashes": [
                 "sha256:1779309f71bf239144b9399d06ae925637cf6634cf6bd131104184531bf67c01",
@@ -78,6 +94,14 @@
             ],
             "index": "pypi",
             "version": "==5.0.13"
+        },
+        "ics": {
+            "hashes": [
+                "sha256:5fcf4d29ec6e7dfcb84120abd617bbba632eb77b097722b7df70e48dbcf26103",
+                "sha256:6743539bca10391635249b87d74fcd1094af20b82098bebf7c7521df91209f05"
+            ],
+            "index": "pypi",
+            "version": "==0.7.2"
         },
         "idna": {
             "hashes": [
@@ -226,7 +250,7 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.9.0.post0"
         },
         "pytz": {
@@ -238,11 +262,27 @@
         },
         "six": {
             "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.17.0"
+        },
+        "tatsu": {
+            "hashes": [
+                "sha256:941e12df8798f444957600346c52a5ff3455f485de5b4570a3a71a00ed896a14",
+                "sha256:df8c216eecd09af9b5b308624f1bfda1e4b5af3d3df1bdc4f331a1e8ea6bc012"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==5.13.1"
+        },
+        "types-python-dateutil": {
+            "hashes": [
+                "sha256:18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb",
+                "sha256:e248a4bc70a486d3e3ec84d0dc30eec3a5f979d6e7ee4123ae043eedbb987f53"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.9.0.20241206"
         },
         "typing-extensions": {
             "hashes": [

--- a/flask-server.py
+++ b/flask-server.py
@@ -9,7 +9,7 @@ from campuspulse_event_ingest_schema import NormalizedEvent
 from flask import Flask, Response, jsonify, request
 from flask import request as frequest
 from flask_cors import CORS
-from ics import Calendar, Event
+from icalendar import Calendar, Event
 from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
@@ -59,10 +59,10 @@ def public_ics():
     for event in alldata:
         try:
             cal_event = Event()
-            cal_event.name = event["title"]
-            cal_event.begin = event["start"]
-            cal_event.end = event["end"]
-            cal_event.description = event["description"]
+            cal_event.add("summary", event["title"])
+            cal_event.add("dtstart", event["start"])
+            cal_event.add("dtend", event["end"])
+            cal_event.add("description", event["description"])
 
             location = event["location"]
             location_str = ", ".join(
@@ -79,9 +79,9 @@ def public_ics():
                 )
             )
             if location_str:
-                cal_event.location = location_str
+                cal_event.add("location", location_str)
 
-            cal.events.add(cal_event)
+            cal.add_component(cal_event)
         except Exception as e:
             print(e)
 
@@ -97,10 +97,10 @@ def get_event(event_id):
         event = next(e for e in alldata if e["id"] == event_id)
         cal = Calendar()
         cal_event = Event()
-        cal_event.name = event["title"]
-        cal_event.begin = event["start"]
-        cal_event.end = event["end"]
-        cal_event.description = event["description"]
+        cal_event.add("summary", event["title"])
+        cal_event.add("dtstart", event["start"])
+        cal_event.add("dtend", event["end"])
+        cal_event.add("description", event["description"])
 
         location = event["location"]
         location_str = ", ".join(
@@ -117,9 +117,9 @@ def get_event(event_id):
             )
         )
         if location_str:
-            cal_event.location = location_str
+            cal_event.add("location", location_str)
 
-        cal.events.add(cal_event)
+        cal.add_component(cal_event)
 
         response = Response(str(cal), mimetype="text/calendar")
         response.headers["Content-Disposition"] = f"attachment; filename={event_id}.ics"

--- a/flask-server.py
+++ b/flask-server.py
@@ -134,7 +134,7 @@ def upload():
 
         if destination.exists():
             timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-            archive_file(destination, timezone, archive_dir)
+            archive_file(destination, timestamp, archive_dir)
 
         temp_dest.rename(destination)
         app.logger.info(f"File saved successfully: {destination}")

--- a/flask-server.py
+++ b/flask-server.py
@@ -1,17 +1,18 @@
-from flask import Flask, Response, jsonify, request, send_file, request as frequest
-from flask_cors import CORS
-from pathlib import Path
-from icalendar import Calendar, Event
 import json
-
-from campuspulse_event_ingest_schema import NormalizedEvent
-from datetime import datetime, date, timezone
 import logging
 import os
+from datetime import date, datetime, timezone
 from functools import wraps
+from pathlib import Path
+
+from campuspulse_event_ingest_schema import NormalizedEvent
+from flask import Flask, Response, jsonify, request, send_file
+from flask import request as frequest
+from flask_cors import CORS
+from icalendar import Calendar, Event
 from werkzeug.utils import secure_filename
 
-app = Flask(__name__) 
+app = Flask(__name__)
 CORS(app)
 
 alldata = []
@@ -25,30 +26,35 @@ archive_dir = Path("./data/archive")
 if not archive_dir.exists():
     archive_dir.mkdir()
 
+
 def check_auth(username, password):
     expected_credential = os.getenv("UPLOAD_CREDENTIAL")
     if expected_credential is None or expected_credential == "":
         return False
-    return username == 'loader' and password == expected_credential
+    return username == "loader" and password == expected_credential
+
 
 def login_required(f):
-    """ basic auth for api """
+    """basic auth for api"""
+
     # https://stackoverflow.com/a/70317010/
     @wraps(f)
     def decorated_function(*args, **kwargs):
         auth = frequest.authorization
         if not auth or not check_auth(auth.username, auth.password):
-            return jsonify({'message': 'Authentication required'}), 401
+            return jsonify({"message": "Authentication required"}), 401
         return f(*args, **kwargs)
+
     return decorated_function
 
-@app.route('/v0/public.json', methods = ['GET'])  
-def public_json():
 
+@app.route("/v0/public.json", methods=["GET"])
+def public_json():
     return jsonify(alldata)
 
-@app.route('/v0/public.ics')
-def public_ics():    
+
+@app.route("/v0/public.ics")
+def public_ics():
     # Create a new calendar
     cal = Calendar()
 
@@ -56,52 +62,60 @@ def public_ics():
     for event in alldata:
         try:
             cal_event = Event()
-            cal_event.add('summary', event['title'])
-            cal_event.add('dtstart', event['start'])
-            cal_event.add('dtend', event['end'])
-            cal_event.add('description', event['description'])
-            
-            location = event['location']
-            location_str = ', '.join(filter(None, [
-                location.get('building'),
-                location.get('room_number'),
-                location.get('street'),
-                location.get('city'),
-                location.get('state'),
-                location.get('zipcode')
-            ]))
-            cal_event.add('location', location_str)
+            cal_event.add("summary", event["title"])
+            cal_event.add("dtstart", event["start"])
+            cal_event.add("dtend", event["end"])
+            cal_event.add("description", event["description"])
+
+            location = event["location"]
+            location_str = ", ".join(
+                filter(
+                    None,
+                    [
+                        location.get("building"),
+                        location.get("room_number"),
+                        location.get("street"),
+                        location.get("city"),
+                        location.get("state"),
+                        location.get("zipcode"),
+                    ],
+                )
+            )
+            cal_event.add("location", location_str)
             cal.add_component(cal_event)
         except Exception as e:
             print(e)
-        
+
     # Create a response object
-    response = Response(cal.to_ical(), mimetype='text/calendar')
-    response.headers['Content-Disposition'] = 'attachment; filename=calendar.ics'
-    
+    response = Response(cal.to_ical(), mimetype="text/calendar")
+    response.headers["Content-Disposition"] = "attachment; filename=calendar.ics"
+
     return response
 
+
 def archive_file(archive_filename, timestamp, archive_path):
-    archive_name = archive_path.with_name(f"{archive_filename.stem}_{timestamp}{archive_filename.suffix}")
+    archive_name = archive_path.with_name(
+        f"{archive_filename.stem}_{timestamp}{archive_filename.suffix}"
+    )
     archive_filename.rename(archive_name)
 
 
-
 def allowed_file(filename):
-    return '.' in filename and filename.endswith(".parsed.normalized.ndjson")
+    return "." in filename and filename.endswith(".parsed.normalized.ndjson")
 
-@app.route('/v0/import', methods=["POST"])
+
+@app.route("/v0/import", methods=["POST"])
 @login_required
 def upload():
     global alldata
     # check if the post request has the file part
-    if 'file' not in request.files:
-        return jsonify({'message': 'No Files Provided'}), 400
-    file = request.files['file']
+    if "file" not in request.files:
+        return jsonify({"message": "No Files Provided"}), 400
+    file = request.files["file"]
     # If the user does not select a file, the browser submits an
     # empty file without a filename.
-    if file.filename == '':
-        return jsonify({'message': 'empty filename'}), 400
+    if file.filename == "":
+        return jsonify({"message": "empty filename"}), 400
     if file and allowed_file(file.filename):
         filename = secure_filename(file.filename)
         destination = input_dir.joinpath(filename)
@@ -109,19 +123,21 @@ def upload():
 
         if temp_dest.exists():
             temp_dest.unlink()
-        
-        # file save parts    
+
+        # file save parts
         try:
-            file.save(temp_dest) 
+            file.save(temp_dest)
         except Exception as e:  # potential catch
             app.logger.error(f"Error saving file {destination}: {e}")
-            return jsonify({'message': 'Error saving file'}), 500 
+            return jsonify({"message": "Error saving file"}), 500
 
         tempsize = temp_dest.stat().st_size
         if tempsize < MINIMUM_FILE_UPLOAD_SIZE_BYTES:
-            app.logger.error(f"Error saving file {destination}: file size {tempsize} not greater than configured minimum {MINIMUM_FILE_UPLOAD_SIZE_BYTES}")
+            app.logger.error(
+                f"Error saving file {destination}: file size {tempsize} not greater than configured minimum {MINIMUM_FILE_UPLOAD_SIZE_BYTES}"
+            )
             temp_dest.unlink()
-            return jsonify({'message': 'File too small'}), 400 
+            return jsonify({"message": "File too small"}), 400
 
         if destination.exists():
             timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
@@ -132,7 +148,7 @@ def upload():
 
         # clean up older files from destination.parent
         for item in input_dir.iterdir():
-            if item!= destination:  # skip destination file
+            if item != destination:  # skip destination file
                 if item.is_file():
                     try:
                         item.unlink()
@@ -140,7 +156,7 @@ def upload():
                         app.logger.error(f"Error deleting file {item}: {e}")
         alldata = []
         update_data(input_dir)
-        return jsonify({'message': 'Success'}), 200
+        return jsonify({"message": "Success"}), 200
 
 
 def update_data(input_dir):
@@ -159,14 +175,18 @@ def update_data(input_dir):
                     if not event.start < datetime.now(timezone.utc):
                         alldata.append(event)
                 except TypeError as e:
-                    if str(e) != "can't compare offset-naive and offset-aware datetimes":
+                    if (
+                        str(e)
+                        != "can't compare offset-naive and offset-aware datetimes"
+                    ):
                         # app.logger.error(f"file {datafile }")
 
                         raise
                     tzun_count += 1
         if tzun_count >= 1:
-            app.logger.warning(f"file {datafile} contains {tzun_count} skipped timezone-unaware events")
-
+            app.logger.warning(
+                f"file {datafile} contains {tzun_count} skipped timezone-unaware events"
+            )
 
     alldata_tmp = sorted(alldata, key=lambda e: e.start)
 
@@ -176,14 +196,13 @@ def update_data(input_dir):
     app.logger.info("Processing event data complete")
 
 
-if __name__ != '__main__':
-
-    gunicorn_error_logger = logging.getLogger('gunicorn.error')
+if __name__ != "__main__":
+    gunicorn_error_logger = logging.getLogger("gunicorn.error")
     app.logger.handlers = gunicorn_error_logger.handlers
     app.logger.setLevel(gunicorn_error_logger.level)
 
 
 update_data(input_dir)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True, port=5000)


### PR DESCRIPTION
Hi, this PR adds an endpoint to get a single event in `.ics` format. It also replaces `icalendar` with `ics`, which offers a cleaner interface for working with iCalendar data. `icalendar` was left in `Pipfile`, in case it's still needed.

Closes #2 